### PR TITLE
Support username and password using curl style url

### DIFF
--- a/src/Pivotal.Discovery.EurekaBase/PivotalEurekaHttpClient.cs
+++ b/src/Pivotal.Discovery.EurekaBase/PivotalEurekaHttpClient.cs
@@ -25,6 +25,7 @@ namespace Pivotal.Discovery.Eureka
     public class PivotalEurekaHttpClient : Steeltoe.Discovery.Eureka.Transport.EurekaHttpClient
     {
         private const int DEFAULT_GETACCESSTOKEN_TIMEOUT = 10000; // Milliseconds
+        private static readonly char[] COLON_DELIMIT = new char[] { ':' };
 
         private IOptionsMonitor<EurekaClientOptions> _configOptions;
 
@@ -61,7 +62,28 @@ namespace Pivotal.Discovery.Eureka
 
         protected override HttpRequestMessage GetRequestMessage(HttpMethod method, Uri requestUri)
         {
-            var request = HttpClientHelper.GetRequestMessage(method, requestUri.ToString(), FetchAccessToken);
+            string rawUri = requestUri.GetComponents(UriComponents.HttpRequestUrl, UriFormat.Unescaped);
+            var request = new HttpRequestMessage(method, rawUri);
+
+            var accessToken = FetchAccessToken();
+            if (accessToken != null)
+            {
+                request = HttpClientHelper.GetRequestMessage(method, rawUri, FetchAccessToken);
+            }
+            else
+            {
+                string rawUserInfo = requestUri.GetComponents(UriComponents.UserInfo, UriFormat.Unescaped);
+
+                request = new HttpRequestMessage(method, rawUri);
+                if (!string.IsNullOrEmpty(rawUserInfo) && rawUserInfo.Contains(":"))
+                {
+                    string[] userInfo = GetUserInfo(rawUserInfo);
+                    if (userInfo.Length >= 2)
+                    {
+                        request = HttpClientHelper.GetRequestMessage(method, rawUri, userInfo[0], userInfo[1]);
+                    }
+                }
+            }
 
             foreach (var header in _headers)
             {
@@ -70,6 +92,17 @@ namespace Pivotal.Discovery.Eureka
 
             request.Headers.Add("Accept", "application/json");
             return request;
+        }
+
+        private string[] GetUserInfo(string userInfo)
+        {
+            string[] result = null;
+            if (!string.IsNullOrEmpty(userInfo))
+            {
+                result = userInfo.Split(COLON_DELIMIT);
+            }
+
+            return result;
         }
     }
 }

--- a/src/Pivotal.Discovery.EurekaBase/PivotalEurekaHttpClient.cs
+++ b/src/Pivotal.Discovery.EurekaBase/PivotalEurekaHttpClient.cs
@@ -63,25 +63,23 @@ namespace Pivotal.Discovery.Eureka
         protected override HttpRequestMessage GetRequestMessage(HttpMethod method, Uri requestUri)
         {
             string rawUri = requestUri.GetComponents(UriComponents.HttpRequestUrl, UriFormat.Unescaped);
+            string rawUserInfo = requestUri.GetComponents(UriComponents.UserInfo, UriFormat.Unescaped);
             var request = new HttpRequestMessage(method, rawUri);
 
-            var accessToken = FetchAccessToken();
-            if (accessToken != null)
+            if (!string.IsNullOrEmpty(rawUserInfo) && rawUserInfo.Contains(":"))
             {
-                request = HttpClientHelper.GetRequestMessage(method, rawUri, FetchAccessToken);
+                string[] userInfo = GetUserInfo(rawUserInfo);
+                if (userInfo.Length >= 2)
+                {
+                    request = HttpClientHelper.GetRequestMessage(method, rawUri, userInfo[0], userInfo[1]);
+                }
             }
             else
             {
-                string rawUserInfo = requestUri.GetComponents(UriComponents.UserInfo, UriFormat.Unescaped);
-
-                request = new HttpRequestMessage(method, rawUri);
-                if (!string.IsNullOrEmpty(rawUserInfo) && rawUserInfo.Contains(":"))
+                var accessToken = FetchAccessToken();
+                if (accessToken != null)
                 {
-                    string[] userInfo = GetUserInfo(rawUserInfo);
-                    if (userInfo.Length >= 2)
-                    {
-                        request = HttpClientHelper.GetRequestMessage(method, rawUri, userInfo[0], userInfo[1]);
-                    }
+                    request = HttpClientHelper.GetRequestMessage(method, rawUri, FetchAccessToken);
                 }
             }
 

--- a/src/Pivotal.Discovery.EurekaBase/PivotalEurekaHttpClient.cs
+++ b/src/Pivotal.Discovery.EurekaBase/PivotalEurekaHttpClient.cs
@@ -66,7 +66,7 @@ namespace Pivotal.Discovery.Eureka
             string rawUserInfo = requestUri.GetComponents(UriComponents.UserInfo, UriFormat.Unescaped);
             var request = new HttpRequestMessage(method, rawUri);
 
-            if (!string.IsNullOrEmpty(rawUserInfo) && rawUserInfo.Contains(":"))
+            if (!string.IsNullOrEmpty(rawUserInfo) && rawUserInfo.IndexOfAny(COLON_DELIMIT) > 0)
             {
                 string[] userInfo = GetUserInfo(rawUserInfo);
                 if (userInfo.Length >= 2)

--- a/src/Pivotal.Discovery.EurekaBase/PivotalEurekaHttpClient.cs
+++ b/src/Pivotal.Discovery.EurekaBase/PivotalEurekaHttpClient.cs
@@ -76,11 +76,7 @@ namespace Pivotal.Discovery.Eureka
             }
             else
             {
-                var accessToken = FetchAccessToken();
-                if (accessToken != null)
-                {
-                    request = HttpClientHelper.GetRequestMessage(method, rawUri, FetchAccessToken);
-                }
+                request = HttpClientHelper.GetRequestMessage(method, rawUri, FetchAccessToken);
             }
 
             foreach (var header in _headers)

--- a/src/Pivotal.Discovery.EurekaBase/PivotalEurekaHttpClient.cs
+++ b/src/Pivotal.Discovery.EurekaBase/PivotalEurekaHttpClient.cs
@@ -25,7 +25,6 @@ namespace Pivotal.Discovery.Eureka
     public class PivotalEurekaHttpClient : Steeltoe.Discovery.Eureka.Transport.EurekaHttpClient
     {
         private const int DEFAULT_GETACCESSTOKEN_TIMEOUT = 10000; // Milliseconds
-        private static readonly char[] COLON_DELIMIT = new char[] { ':' };
 
         private IOptionsMonitor<EurekaClientOptions> _configOptions;
 
@@ -62,28 +61,7 @@ namespace Pivotal.Discovery.Eureka
 
         protected override HttpRequestMessage GetRequestMessage(HttpMethod method, Uri requestUri)
         {
-            string rawUri = requestUri.GetComponents(UriComponents.HttpRequestUrl, UriFormat.Unescaped);
-            var request = new HttpRequestMessage(method, rawUri);
-
-            var accessToken = FetchAccessToken();
-            if (accessToken != null)
-            {
-                request = HttpClientHelper.GetRequestMessage(method, rawUri, FetchAccessToken);
-            }
-            else
-            {
-                string rawUserInfo = requestUri.GetComponents(UriComponents.UserInfo, UriFormat.Unescaped);
-
-                request = new HttpRequestMessage(method, rawUri);
-                if (!string.IsNullOrEmpty(rawUserInfo) && rawUserInfo.Contains(":"))
-                {
-                    string[] userInfo = GetUserInfo(rawUserInfo);
-                    if (userInfo.Length >= 2)
-                    {
-                        request = HttpClientHelper.GetRequestMessage(method, rawUri, userInfo[0], userInfo[1]);
-                    }
-                }
-            }
+            var request = HttpClientHelper.GetRequestMessage(method, requestUri.ToString(), FetchAccessToken);
 
             foreach (var header in _headers)
             {
@@ -92,17 +70,6 @@ namespace Pivotal.Discovery.Eureka
 
             request.Headers.Add("Accept", "application/json");
             return request;
-        }
-
-        private string[] GetUserInfo(string userInfo)
-        {
-            string[] result = null;
-            if (!string.IsNullOrEmpty(userInfo))
-            {
-                result = userInfo.Split(COLON_DELIMIT);
-            }
-
-            return result;
         }
     }
 }

--- a/test/Pivotal.Discovery.EurekaBase.Test/PivotalEurekaHttpClientTest.cs
+++ b/test/Pivotal.Discovery.EurekaBase.Test/PivotalEurekaHttpClientTest.cs
@@ -1,0 +1,58 @@
+﻿// Copyright 2017 the original author or authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Steeltoe.Discovery.Eureka;
+using System;
+using System.Net.Http;
+using Xunit;
+
+namespace Pivotal.Discovery.EurekaBase.Test
+{
+    public class PivotalEurekaHttpClientTest
+    {
+        [Fact]
+        public void GetRequestMessage_No_Auth_When_Creds_Not_In_Url()
+        {
+            // arrange
+            var clientOptions = new EurekaClientOptions { ServiceUrl = "http://boo:123/eureka/" };
+            var optionsMonitor = new TestOptionMonitorWrapper<EurekaClientOptions>(clientOptions);
+            var client = new TestPivotalEurekaHttpClient(optionsMonitor);
+
+            // act
+            var result = client.PublicGetRequestMessage(HttpMethod.Post, new Uri(clientOptions.EurekaServerServiceUrls));
+
+            // assert
+            Assert.Equal(HttpMethod.Post, result.Method);
+            Assert.Equal(new Uri("http://boo:123/eureka/"), result.RequestUri);
+            Assert.False(result.Headers.Contains("Authorization"));
+        }
+
+        [Fact]
+        public void GetRequestMessage_Adds_Auth_When_Creds_In_Url()
+        {
+            // arrange
+            var clientOptions = new EurekaClientOptions { ServiceUrl = "http://user:pass@boo:123/eureka/" };
+            var optionsMonitor = new TestOptionMonitorWrapper<EurekaClientOptions>(clientOptions);
+            var client = new TestPivotalEurekaHttpClient(optionsMonitor);
+
+            // act
+            var result = client.PublicGetRequestMessage(HttpMethod.Post, new Uri(clientOptions.EurekaServerServiceUrls));
+
+            // assert
+            Assert.Equal(HttpMethod.Post, result.Method);
+            Assert.Equal(new Uri("http://boo:123/eureka/"), result.RequestUri);
+            Assert.True(result.Headers.Contains("Authorization"));
+        }
+    }
+}

--- a/test/Pivotal.Discovery.EurekaBase.Test/TestOptionMonitorWrapper.cs
+++ b/test/Pivotal.Discovery.EurekaBase.Test/TestOptionMonitorWrapper.cs
@@ -1,0 +1,39 @@
+﻿// Copyright 2017 the original author or authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.Extensions.Options;
+using System;
+
+namespace Pivotal.Discovery.EurekaBase.Test
+{
+    public class TestOptionMonitorWrapper<T> : IOptionsMonitor<T>
+    {
+        public TestOptionMonitorWrapper(T opt)
+        {
+            CurrentValue = opt;
+        }
+
+        public T CurrentValue { get; private set; }
+
+        public T Get(string name)
+        {
+            return CurrentValue;
+        }
+
+        public IDisposable OnChange(Action<T, string> listener)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/test/Pivotal.Discovery.EurekaBase.Test/TestPivotalEurekaHttpClient.cs
+++ b/test/Pivotal.Discovery.EurekaBase.Test/TestPivotalEurekaHttpClient.cs
@@ -1,0 +1,36 @@
+﻿// Copyright 2017 the original author or authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Pivotal.Discovery.Eureka;
+using Steeltoe.Discovery.Eureka;
+using System;
+using System.Net.Http;
+
+namespace Pivotal.Discovery.EurekaBase.Test
+{
+    public class TestPivotalEurekaHttpClient : PivotalEurekaHttpClient
+    {
+        public TestPivotalEurekaHttpClient(IOptionsMonitor<EurekaClientOptions> config, ILoggerFactory logFactory = null)
+            : base(config, logFactory)
+        {
+        }
+
+        public HttpRequestMessage PublicGetRequestMessage(HttpMethod method, Uri requestUri)
+        {
+            return GetRequestMessage(method, requestUri);
+        }
+    }
+}


### PR DESCRIPTION
Config item **eureka:client:serviceUrl**  now support username and password curl style url.

Hi Tim,

As discussed, I have updated the Pivotal.Discovery.EurekaBase url to support username and password. I also tried to add nunit test but I not sure its possible with this library and the location where the code is changed. If you guide me I would be happy to add them.